### PR TITLE
Fix CSS not loading in production build

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import '../styles/global.css';
 export interface Props {
   title?: string;
   description?: string;
@@ -15,7 +16,6 @@ const { title = 'Branimir Georgiev', description = 'Automation Engineer. Softwar
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/src/styles/global.css" />
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## Summary
- Import `global.css` via Astro frontmatter instead of a `<link>` tag
- Astro does not expose `/src/` in the production build, so the `<link href="/src/styles/global.css">` approach causes a 404 in production while working fine in dev

## Test plan
- [ ] `npm run build && npm run preview` — verify styles load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)