### PR TITLE
Refresh content across projects, skills, experience, and about

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal portfolio site for Branimir Georgiev — automation engineer, software engineer, and founder at the OT/IT boundary.
 
-**Live site:** https://braboj.github.io
+**Live site:** https://braboj.me
 
 ---
 

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -3,7 +3,7 @@ import about from '../data/about.json';
 ---
 <section id="about" class="section section-alt">
   <div class="container">
-    <h2 class="section-title reveal">About</h2>
+    <h2 class="section-title reveal">About <span class="about-cursor">ツ</span></h2>
 
     {about.map((block) => (
       <div class="about-block reveal">

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -12,9 +12,6 @@ import projects from '../data/projects.json';
             <p class="project-tagline">{project.tagline}</p>
           </div>
           <p class="project-description">{project.description}</p>
-          <div class="tags">
-            {project.tags.map((tag) => <span class="tag">{tag}</span>)}
-          </div>
           {project.url && (
             <a href={project.url} class="project-link" target="_blank" rel="noopener noreferrer">View →</a>
           )}

--- a/src/data/about.json
+++ b/src/data/about.json
@@ -12,7 +12,8 @@
     "years": "2019 – 2025",
     "paragraphs": [
       "At Hilscher, Branimir moved into software and discovered Python. He hit a gap no existing library could fill: protocol stacks built ONLY for communication, not for testing. You cannot craft malformed packets. You cannot simulate edge cases the spec does not cover.",
-      "That gap is where Imbra Connect began. The SDK grew to cover DeviceNet, CAN, Modbus, OPC-UA, and MQTT. Brutal deadlines from tier-1 American semiconductor equipment manufacturers. Impossible milestones. All delivered. The model was lean: developer and tester working in parallel, every artifact shipped already tested. Branimir had a penchant for crashing things on a Friday afternoon, or right before a public holiday — because that is when developers reveal their true dedication. He trained six engineers and earned the nickname <em>the bastard from heaven</em> in tester mode and <em>master-blaster</em> in developer mode."
+      "That gap is where Imbra Connect began. The SDK grew to cover DeviceNet, CAN, Modbus, OPC-UA, and MQTT. Brutal deadlines from tier-1 American semiconductor equipment manufacturers. Impossible milestones. All delivered. The model was lean: developer and tester working in parallel, every artifact shipped already tested.",
+      "Branimir had a penchant for crashing things on a Friday afternoon, or right before a public holiday — because that is when developers reveal their true dedication. He trained six engineers and earned the nickname <em>the bastard from heaven</em> in tester mode and <em>master-blaster</em> in developer mode."
     ]
   },
   {
@@ -26,7 +27,7 @@
     "heading": "When the Prophet goes to the mountain",
     "years": "2026 – Present",
     "paragraphs": [
-      "As the old proverb goes — if the mountain won't come to Muhammad, Muhammad must go to the mountain. Imbra.Soft was founded after Branimir's daughter was born and an inspiration followed: help people prototype and build with low cost and high quality, bring back the fun of engineering and experimenting for young and professionals alike. Build tools that last. Every product comes from 15 years of knowing firsthand what it costs when the software fails — and the people that have to live with the consequences. <blockquote class=\"statement\">\"The complexity is ours to solve.\"</blockquote>"
+      "As the old proverb goes — if the mountain won't come to Muhammad, Muhammad must go to the mountain. Imbra was founded after Branimir's daughter was born and an inspiration followed: help people prototype and build with low cost and high quality, bring back the fun of engineering and experimenting for young and professionals alike. Build tools that last. Every product comes from 15 years of knowing firsthand what it costs when the software fails — and the people that have to live with the consequences. <blockquote class=\"statement\">\"The complexity is ours to solve.\"</blockquote>"
     ]
   }
 ]

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -13,7 +13,7 @@
     "period": "2019 – 04/2025",
     "location": "Varna, Bulgaria",
     "description": "Authored production-quality industrial protocol libraries in Python (MQTT, DeviceNet, OpenModbus over TLS). Built comprehensive and scalable test frameworks. Refactored legacy code into maintainable architecture using clean code principles. Created and maintained training programs for new recruits covering Python, OS, multi-threading, version control, and testing.",
-    "tags": ["Python", "Flask", "Playwright", "unittest", "Docker", "Git", "SVN", "DeviceNet", "CAN", "MQTT", "Modbus"]
+    "tags": ["Python", "netX", "Flask", "unittest", "Docker", "Git", "SVN", "DeviceNet", "CAN", "MQTT", "Modbus"]
   },
   {
     "company": "Solvay Sodi",

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,23 +1,20 @@
 [
   {
-    "name": "Imbra Connect",
-    "tagline": "Protocol SDK for industrial communication",
-    "description": "A Python SDK for DeviceNet, CAN, Modbus, OPC-UA, and MQTT — with packet crafting and adversarial testing as first-class features. Built to fill the gap no existing library could fill: testing the edge cases the spec doesn't cover.",
-    "tags": ["Python", "DeviceNet", "CAN", "Modbus", "OPC-UA", "MQTT"],
-    "url": "https://imbra.io"
-  },
-  {
-    "name": "ImBrain",
-    "tagline": "Industrial historian built for the plant floor",
-    "description": "An industrial historian that does what historians rarely do — actually work the way operators need them to. Built from firsthand experience with PxTrend and years of understanding what data matters on a plant floor.",
-    "tags": ["Python", "Time-Series", "Industrial Data", "OPC-UA"],
+    "name": "imbra.io",
+    "tagline": "Home of industrial software for the OT/IT boundary",
+    "description": "The company site for Imbra — where industrial communication SDKs, historians, and tools for the plant floor are built and documented.",
     "url": "https://imbra.io"
   },
   {
     "name": "Code with Branko",
     "tagline": "Practical courses for engineers at the OT/IT boundary",
     "description": "Guides and courses for engineers working at the intersection of operational technology and information technology. No fluff — built for people who need to ship.",
-    "tags": ["Python", "Industrial Automation", "Tutorials"],
     "url": "https://www.codewithbranko.com"
+  },
+  {
+    "name": "braboj.github.io",
+    "tagline": "Personal portfolio and engineering profile",
+    "description": "This site — a minimal portfolio built with Astro, showcasing experience, skills, and projects. Open source and deployed via GitHub Pages.",
+    "url": "https://github.com/braboj/braboj.github.io"
   }
 ]

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -10,6 +10,7 @@
     { "label": "Publications", "href": "#publications" },
     { "label": "Get in Touch", "href": "#contact" }
   ],
+
   "contact": {
     "email": "contact@imbra.io",
     "linkedin": "https://linkedin.com/in/branimir-georgiev",

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -1,26 +1,26 @@
 [
   {
     "category": "Technical",
-    "items": ["Software Engineering", "Quality Engineering", "Python Development", "Docker", "CI/CD Pipelines", "C", "Go"]
+    "items": ["Software Engineering", "QA Engineering", "TDD", "BDD", "Python", "C", "Go", "Docker", "CI/CD Pipelines"]
   },
   {
     "category": "Industrial Automation",
-    "items": ["Siemens PLCs", "Honeywell", "Profibus", "Profinet", "SCL", "HMI", "PID Tuning", "Advanced Process Control", "ATEX/IECEx"]
+    "items": ["Siemens PLCs", "TIA Portal", "Honeywell", "SCL", "HMI", "PID Tuning", "Advanced Process Control", "ATEX/IECEx"]
   },
   {
     "category": "Industrial Protocols",
-    "items": ["DeviceNet", "Modbus", "MQTT", "OPC-UA", "OPC-DA", "OPC-XDA", "Profibus", "Profinet", "MOST"]
+    "items": ["CAN", "CANopen", "CIP", "DeviceNet", "EtherNet/IP", "HART", "IO-Link", "Profibus", "Profinet", "Modbus", "MQTT", "Sparkplug", "OPC-DA", "OPC-UA", "MOST", "FlexRay", "LoRaWAN", "Zigbee"]
   },
   {
     "category": "Software & Tools",
-    "items": ["Python", "Flask", "Docker", "Azure", "GitLab", "GitHub", "ElasticSearch", "pytest", "pydantic", "arc42", "JIRA"]
+    "items": ["PostgreSQL", "TimescaleDB", "ElasticSearch", "Docker", "Podman", "Azure", "Grafana", "GitLab", "GitHub", "REST", "gRPC", "arc42", "Mermaid", "JIRA"]
   },
   {
     "category": "Professional",
-    "items": ["Project Ownership", "Documentation", "Mentoring", "Training", "Lean Agile", "SOLID Principles", "Design Patterns"]
+    "items": ["Project Ownership", "Project Management", "Mentoring", "Training", "Documentation", "Lean Agile", "SOLID Principles", "Design Patterns"]
   },
   {
     "category": "Languages",
-    "items": ["Bulgarian (Native)", "English (Professional)", "German (Professional)", "French (Limited)"]
+    "items": ["Bulgarian (Native)", "English (Professional)", "German (Conversational)", "French (Limited)"]
   }
 ]

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -418,6 +418,13 @@ code {
   letter-spacing: -0.01em;
 }
 
+.about-cursor {
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  color: var(--color-accent);
+  margin-left: 8px;
+}
+
 .about-years {
   font-family: var(--font-mono);
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- **Projects**: replaced product cards with website entries (imbra.io, codewithbranko.com, braboj.github.io); removed tags
- **Skills**: overhauled all categories — expanded protocols (CAN, CIP, EtherNet/IP, HART, IO-Link, Sparkplug, FlexRay, LoRaWAN, Zigbee), added tools (PostgreSQL, TimescaleDB, Grafana, Podman, REST, gRPC, Mermaid), renamed to QA Engineering, added TDD/BDD and TIA Portal; reordered logically throughout
- **Experience**: added netX, removed Playwright from Hilscher tags
- **About**: renamed Imbra.Soft → Imbra; split paragraph for readability; added static `ツ` cursor to section heading
- **README**: updated live site URL to braboj.me

## Test plan
- [ ] `npm run dev` — verify all sections render correctly
- [ ] Projects section shows 3 website cards with no tags
- [ ] Skills section displays all new protocols and tools
- [ ] About heading shows `ツ` in accent monospace
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)