### PR TITLE
Opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: pages
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env variable to the deploy workflow
- Resolves deprecation warnings for `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/upload-pages-artifact`
- Opts in ahead of the forced migration on June 2nd, 2026

## Test plan
- [ ] Verify build runs without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)