### PR TITLE
Expand Edgar Poth acknowledgement in About section

### DIFF
--- a/src/data/about.json
+++ b/src/data/about.json
@@ -20,7 +20,8 @@
     "heading": "The best documentation is a conversation",
     "years": "2025 – Present",
     "paragraphs": [
-      "At Heidelberg Materials, Branimir worked on PxTrend — an industrial historian built by Paranext. When the setup stalled, he drove to the nearest plant in Devnya, talked to the operators, learned from the clients, learned from the creator, and built understanding the only way that works — by experimenting, using it, and solving problems. The understanding of what a historian should do became the foundation for ImBrain. A special thanks to Edgar Poth, founder of Paranext, for sharing his knowledge directly."
+      "At Heidelberg Materials, Branimir worked on PxTrend — an industrial historian built by Paranext. When the setup stalled, he drove to the nearest plant in Devnya, talked to the operators, learned from the clients, learned from the creator, and built understanding the only way that works — by experimenting, using it, and solving problems. The understanding of what a historian should do became the foundation for ImBrain.",
+      "A special thanks to Edgar Poth, founder of Paranext, for sharing his knowledge directly — shadowing him from 4am to 11pm through installations, upgrades, and live migrations of PxTrend was worth more than any documentation."
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Added detail about shadowing Edgar Poth (Paranext founder) from 4am to 11pm through PxTrend installations, upgrades, and live migrations
- Split acknowledgement into its own paragraph for readability

## Test plan
- [ ] Verify About section renders the new paragraph correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)