### PR TITLE
Update hero title to Engineer. Hacker. Vibe Coder. Founder.

### DIFF
--- a/src/data/site.json
+++ b/src/data/site.json
@@ -1,6 +1,6 @@
 {
   "name": "Branimir Georgiev",
-  "title": "Automation Engineer. Software Engineer. Founder.",
+  "title": "Engineer. Hacker. Vibe Coder. Founder.",
   "summary": "Dipl.-Ing. alumnus of Karlsruhe Institute of Technology (KIT). 15 years on industrial plant floors and software. Built protocol SDKs, industrial historians, and control systems for some of Bulgaria's largest plants and global manufacturing firms. Now building software tools at Imbra.io that make the OT/IT boundary easier to cross.",
   "nav": [
     { "label": "About",        "href": "#about" },


### PR DESCRIPTION
## Summary
- Replaces the formal title with a more personal, identity-driven one
- Reflects the hacker mindset, AI-augmented workflow, and founder role

## Test plan
- [x] Verify hero title renders correctly on `npm run dev`
- [x] Check mobile layout — title wraps gracefully at small breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)