### PR TITLE
Refactor hero title to two-line format

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -44,10 +44,8 @@ import site from '../data/site.json';
 
       <div class="hero-grid-title">
         <h1 class="hero-title">
-          {site.title.split('. ').map((line) => (
-            <span class="hero-title-line">
-              {line.replace(/\.$/, '')}.
-            </span>
+          {site.title.map((line) => (
+            <span class="hero-title-line">{line}</span>
           ))}
         </h1>
       </div>

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -1,6 +1,6 @@
 {
   "name": "Branimir Georgiev",
-  "title": "Engineer. Hacker. Vibe Coder. Founder.",
+  "title": ["Engineer. Hacker.", "Vibe Coder. Founder."],
   "summary": "Dipl.-Ing. alumnus of Karlsruhe Institute of Technology (KIT). 15 years on industrial plant floors and software. Built protocol SDKs, industrial historians, and control systems for some of Bulgaria's largest plants and global manufacturing firms. Now building software tools at Imbra.io that make the OT/IT boundary easier to cross.",
   "nav": [
     { "label": "About",        "href": "#about" },


### PR DESCRIPTION
## Summary
- Changes `title` in `site.json` from a single string to a two-element array
- Updates `Hero.astro` to iterate over the array directly
- Renders as "Engineer. Hacker." / "Vibe Coder. Founder." — two balanced lines

## Test plan
- [x] Verify hero title renders as two lines on `npm run dev`
- [x] Check mobile layout wraps gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)