### PR TITLE
Update Edgar acknowledgement: documentation → technical book

### DIFF
--- a/src/data/about.json
+++ b/src/data/about.json
@@ -21,7 +21,7 @@
     "years": "2025 – Present",
     "paragraphs": [
       "At Heidelberg Materials, Branimir worked on PxTrend — an industrial historian built by Paranext. When the setup stalled, he drove to the nearest plant in Devnya, talked to the operators, learned from the clients, learned from the creator, and built understanding the only way that works — by experimenting, using it, and solving problems. The understanding of what a historian should do became the foundation for ImBrain.",
-      "A special thanks to Edgar Poth, founder of Paranext, for sharing his knowledge directly — shadowing him from 4am to 11pm through installations, upgrades, and live migrations of PxTrend was worth more than any documentation."
+      "A special thanks to Edgar Poth, founder of Paranext, for sharing his knowledge directly — shadowing him from 4am to 11pm through installations, upgrades, and live migrations of PxTrend was worth more than any technical book."
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Replaces "any documentation" with "any technical book" in the About section Edgar Poth acknowledgement

🤖 Generated with [Claude Code](https://claude.com/claude-code)