### PR TITLE
Move SOLID Principles and Design Patterns to Technical skills

### DIFF
--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -1,7 +1,7 @@
 [
   {
     "category": "Technical",
-    "items": ["Software Engineering", "QA Engineering", "TDD", "BDD", "Python", "C", "Go", "Docker", "CI/CD Pipelines"]
+    "items": ["Software Engineering", "QA Engineering", "TDD", "BDD", "SOLID Principles", "Design Patterns", "Python", "C", "Go", "Docker", "CI/CD Pipelines"]
   },
   {
     "category": "Industrial Automation",
@@ -17,7 +17,7 @@
   },
   {
     "category": "Professional",
-    "items": ["Project Ownership", "Project Management", "Mentoring", "Training", "Documentation", "Lean Agile", "SOLID Principles", "Design Patterns"]
+    "items": ["Project Ownership", "Project Management", "Mentoring", "Training", "Documentation", "Lean Agile"]
   },
   {
     "category": "Languages",


### PR DESCRIPTION
## Summary
- Moves "SOLID Principles" and "Design Patterns" from the Professional category to Technical
- These are engineering fundamentals, not soft/professional skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)