### PR TITLE
MVP content pass: experience, projects, tutorials, publications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ All editable content lives in `src/data/` as JSON. Never hardcode content that a
 | `src/data/experience.json` | Work experience entries                       |
 | `src/data/skills.json`     | Skill categories and items                    |
 | `src/data/projects.json`   | Portfolio/demo project cards                  |
+| `src/data/tutorials.json`  | Tutorial repository cards                     |
 | `src/data/publications.json` | Academic publications                       |
 
 Note: `src/content/` is intentionally avoided — Astro reserves that path for Content Collections.
@@ -58,6 +59,7 @@ src/components/
 ├── Experience.astro      # Work history — data-driven from experience.json
 ├── Skills.astro          # Skills grid — data-driven from skills.json
 ├── Projects.astro        # Project cards — data-driven from projects.json
+├── Tutorials.astro       # Tutorial cards — data-driven from tutorials.json
 ├── Publications.astro    # Publications list — data-driven from publications.json
 ├── Contact.astro         # Contact section — email, LinkedIn, GitHub, CV download
 └── Footer.astro          # Copyright and legal links

--- a/src/components/Publications.astro
+++ b/src/components/Publications.astro
@@ -3,7 +3,7 @@ import publications from '../data/publications.json';
 ---
 <section id="publications" class="section section-alt">
   <div class="container">
-    <h2 class="section-title reveal">Publications</h2>
+    <h2 class="section-title reveal">Academic Publications</h2>
     <div class="publications-list">
       {publications.map((pub) => (
         <div class="publication-item reveal">

--- a/src/components/Tutorials.astro
+++ b/src/components/Tutorials.astro
@@ -1,0 +1,22 @@
+---
+import tutorials from '../data/tutorials.json';
+---
+<section id="tutorials" class="section">
+  <div class="container">
+    <h2 class="section-title reveal">Tutorials</h2>
+    <div class="projects-grid">
+      {tutorials.map((tutorial) => (
+        <div class="project-card reveal">
+          <div class="project-header">
+            <h3 class="project-name">{tutorial.name}</h3>
+            <p class="project-tagline">{tutorial.tagline}</p>
+          </div>
+          <p class="project-description">{tutorial.description}</p>
+          {tutorial.url && (
+            <a href={tutorial.url} class="project-link" target="_blank" rel="noopener noreferrer">View →</a>
+          )}
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -1,8 +1,16 @@
 [
   {
+    "company": "Imbra.io",
+    "role": "Founder & Lead Engineer",
+    "period": "2026 – Present",
+    "location": "Varna, Bulgaria",
+    "description": "Building software tools at the OT/IT boundary — from protocol SDKs to industrial historians. Products include ImBrain, a historian built on 15 years of firsthand experience with what industrial software costs when it fails. Sole developer and engineer: design, implementation, testing, and deployment.",
+    "tags": ["Python", "Protocol SDKs", "DeviceNet", "Modbus", "OPC-UA", "MQTT", "Docker", "FastAPI", "TimescaleDB", "Grafana"]
+  },
+  {
     "company": "Heidelberg Materials Digital Hub Varna",
     "role": "Senior Software Engineer",
-    "period": "2026 – Present",
+    "period": "2025 – Present",
     "location": "Varna, Bulgaria",
     "description": "Providing L3 support for PxTrend, a legacy data historian from Paranext — delivering hotfixes and new features. Developing agent-based ETL pipelines to transfer data from OT to IT systems. Extending GitLab CI/CD pipelines for quality control automation. Authoring technical documentation in arc42 format.",
     "tags": ["Python", "Flask", "FastAPI", "Azure", "Docker", "GitLab", "ElasticSearch", "pytest", "pydantic", "arc42"]

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -2,7 +2,7 @@
   {
     "name": "imbra.io",
     "tagline": "Home of industrial software for the OT/IT boundary",
-    "description": "The company site for Imbra — where industrial communication SDKs, historians, and tools for the plant floor are built and documented.",
+    "description": "The company site for Imbra — home of Imbra Connect (industrial protocol SDKs for DeviceNet, Modbus, OPC-UA, and MQTT) and ImBrain (an industrial historian built for the plant floor).",
     "url": "https://imbra.io"
   },
   {
@@ -16,5 +16,35 @@
     "tagline": "Personal portfolio and engineering profile",
     "description": "This site — a minimal portfolio built with Astro, showcasing experience, skills, and projects. Open source and deployed via GitHub Pages.",
     "url": "https://github.com/braboj/braboj.github.io"
+  },
+  {
+    "name": "demo-sensor-app",
+    "tagline": "Simulated sensor data sampling with REST and Angular",
+    "description": "A full-stack demo app simulating industrial sensor data — REST API built with Flask, visualised with Angular.",
+    "url": "https://github.com/braboj/demo-sensor-app"
+  },
+  {
+    "name": "demo-the-great-wall",
+    "tagline": "REST API with multiprocessing and Django",
+    "description": "A REST API demo using Django and multiprocessing — built to demonstrate parallel workload handling patterns.",
+    "url": "https://github.com/braboj/demo-the-great-wall"
+  },
+  {
+    "name": "demo-randomgen",
+    "tagline": "Random number generator REST API with Flask",
+    "description": "A minimal REST API demo built with Flask — clean starting point for API design patterns.",
+    "url": "https://github.com/braboj/demo-randomgen"
+  },
+  {
+    "name": "demo-hvlp",
+    "tagline": "Simplified MQTT protocol demo for training",
+    "description": "A simplified MQTT protocol implementation used for training engineers on industrial messaging patterns.",
+    "url": "https://github.com/braboj/demo-hvlp"
+  },
+  {
+    "name": "demo-state-machines",
+    "tagline": "State machine implementation in C",
+    "description": "A sample implementation of state machines in C — a fundamental pattern in embedded and industrial control systems.",
+    "url": "https://github.com/braboj/demo-state-machines"
   }
 ]

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -1,12 +1,13 @@
 {
   "name": "Branimir Georgiev",
   "title": ["Engineer. Hacker.", "Vibe Coder. Founder."],
-  "summary": "Dipl.-Ing. alumnus of Karlsruhe Institute of Technology (KIT). 15 years on industrial plant floors and software. Built protocol SDKs, industrial historians, and control systems for some of Bulgaria's largest plants and global manufacturing firms. Now building software tools at Imbra.io that make the OT/IT boundary easier to cross.",
+  "summary": "Dipl.-Ing. alumnus of Karlsruhe Institute of Technology (KIT). 15 years on industrial plant floors and in software. Built protocol SDKs, industrial historians, and control systems for some of Bulgaria's largest plants and global manufacturing firms. Now founder and lead engineer at Imbra.io — building tools that make the OT/IT boundary easier to cross.",
   "nav": [
     { "label": "About",        "href": "#about" },
     { "label": "Experience",   "href": "#experience" },
     { "label": "Skills",       "href": "#skills" },
     { "label": "Projects",     "href": "#projects" },
+    { "label": "Tutorials",    "href": "#tutorials" },
     { "label": "Publications", "href": "#publications" },
     { "label": "Get in Touch", "href": "#contact" }
   ],

--- a/src/data/tutorials.json
+++ b/src/data/tutorials.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "tutorial-azure",
+    "tagline": "Azure cloud training",
+    "description": "A hands-on Azure tutorial covering cloud fundamentals — compute, storage, and deployment for engineers new to the platform.",
+    "url": "https://github.com/braboj/tutorial-azure"
+  },
+  {
+    "name": "tutorial-docker",
+    "tagline": "Docker training program",
+    "description": "A structured Docker training program covering containers, images, volumes, and compose — built for engineers moving workloads to containers.",
+    "url": "https://github.com/braboj/tutorial-docker"
+  },
+  {
+    "name": "tutorial-git",
+    "tagline": "Let's learn git",
+    "description": "A beginner-friendly Git tutorial covering the core workflow — commits, branches, merges, and collaboration patterns.",
+    "url": "https://github.com/braboj/tutorial-git"
+  },
+  {
+    "name": "tutorial-microprocessor",
+    "tagline": "Basic components of a CPU explained",
+    "description": "A simple tutorial on CPU architecture — registers, ALU, memory, and instruction cycles for engineers interested in low-level systems.",
+    "url": "https://github.com/braboj/tutorial-microprocessor"
+  },
+  {
+    "name": "tutorial-modbus",
+    "tagline": "Open Modbus protocol tutorial",
+    "description": "A practical tutorial on the Modbus protocol — covering framing, function codes, and implementation patterns for industrial communication.",
+    "url": "https://github.com/braboj/tutorial-modbus"
+  },
+  {
+    "name": "tutorial-networks",
+    "tagline": "Network and protocols tutorial",
+    "description": "A practical guide to networking fundamentals and protocol concepts — from OSI layers to hands-on packet analysis.",
+    "url": "https://github.com/braboj/tutorial-networks"
+  },
+  {
+    "name": "tutorial-openssl",
+    "tagline": "OpenSSL command line interface tutorial",
+    "description": "A short tutorial on the basic features of the OpenSSL CLI — certificates, keys, and TLS fundamentals for engineers.",
+    "url": "https://github.com/braboj/tutorial-openssl"
+  },
+  {
+    "name": "tutorial-os",
+    "tagline": "Into the depths of parallel execution",
+    "description": "A deep dive into operating system concepts with a focus on parallel execution — processes, threads, and synchronisation for systems engineers.",
+    "url": "https://github.com/braboj/tutorial-os"
+  },
+  {
+    "name": "tutorial-python",
+    "tagline": "Source code for \"Learn Python by Example\"",
+    "description": "Companion repository for the Learn Python by Example course — practical examples for engineers picking up Python.",
+    "url": "https://github.com/braboj/tutorial-python"
+  },
+  {
+    "name": "tutorial-testing",
+    "tagline": "Let's learn breaking things",
+    "description": "A hands-on testing tutorial covering how to break software systematically — written for engineers who need to ship reliable code.",
+    "url": "https://github.com/braboj/tutorial-testing"
+  }
+]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import About from '../components/About.astro';
 import Experience from '../components/Experience.astro';
 import Skills from '../components/Skills.astro';
 import Projects from '../components/Projects.astro';
+import Tutorials from '../components/Tutorials.astro';
 import Publications from '../components/Publications.astro';
 import Contact from '../components/Contact.astro';
 import Footer from '../components/Footer.astro';
@@ -18,6 +19,7 @@ import Footer from '../components/Footer.astro';
     <Experience />
     <Skills />
     <Projects />
+    <Tutorials />
     <Publications />
     <Contact />
   </main>


### PR DESCRIPTION
## Summary
- Add Imbra.io as Founder & Lead Engineer experience entry
- Fix Heidelberg Materials period (2026 → 2025)
- Update imbra.io project card to name Imbra Connect and ImBrain explicitly
- Split projects into separate Projects and Tutorials sections
- Add 5 demo repos and 10 tutorial repos as individual cards
- Rename Publications section heading to "Academic Publications"
- Update hero summary to foreground the founder role
- Update CLAUDE.md with Tutorials component and tutorials.json entries

## Test plan
- [x] Verify Tutorials section renders after Projects on `npm run dev`
- [x] Check Tutorials nav link scrolls correctly
- [x] Confirm Imbra.io appears at top of Experience
- [x] Check mobile layout for new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)