### PR TITLE
docs: document release process via PR for version tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Before every commit, update all relevant documentation:
 - Commit messages must use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `style:`, `test:`
 - Versioning follows `vA.B.C.D` — A=major, B=minor, C=build, D=hotfix
 - Releases are marked with an empty `chore: release vA.B.C.D` commit followed by a git tag
+- Release process: create `chore/release-vA.B.C.D` branch → empty commit → PR → merge → tag `vA.B.C.D` on main
 - Always work on a branch — never commit directly to `main`
 - Exception: documentation-only changes (`docs/`, `README.md`, `CLAUDE.md`) may go directly to `main`
 - Branch naming: `feature/description` or `fix/description`


### PR DESCRIPTION
## Summary
- Clarify release process: empty `chore: release vA.B.C.D` commit must go through a PR, not direct push to main
- Respects branch protection rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)