### PR TITLE
docs: add onboarding guide and rewrite playbook for this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,23 +49,8 @@ Note: `src/content/` is intentionally avoided — Astro reserves that path for C
 
 ## Component architecture
 
-```
-src/components/
-├── interactive/          # React islands — only components that need JS
-│   └── HamburgerMenu.tsx # Mobile nav toggle
-├── Nav.astro             # Static nav shell — mounts HamburgerMenu island
-├── Hero.astro            # Hero section with photo, title, social links
-├── About.astro           # Biography — data-driven from about.json
-├── Experience.astro      # Work history — data-driven from experience.json
-├── Skills.astro          # Skills grid — data-driven from skills.json
-├── Projects.astro        # Project cards — data-driven from projects.json
-├── Tutorials.astro       # Tutorial cards — data-driven from tutorials.json
-├── Publications.astro    # Publications list — data-driven from publications.json
-├── Contact.astro         # Contact section — email, LinkedIn, GitHub, CV download
-└── Footer.astro          # Copyright and legal links
-```
-
-**Rule:** default to `.astro`. Only reach for React (`.tsx`) when client-side state is required.
+See `README.md` for the full project structure. Key rule: default to
+`.astro`. Only reach for React (`.tsx`) when client-side state is required.
 
 ## Pages
 
@@ -113,6 +98,8 @@ These are the non-negotiable standards for this project:
 
 **Documentation**
 - `CLAUDE.md` and `README.md` must always reflect the actual codebase
+- `docs/ONBOARDING.md` — onboarding guide for new contributors
+- `docs/PLAYBOOK.md` — operational reference for common tasks
 - No references to non-existent files, components, or services
 
 ## Documentation rule

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ src/
 │   ├── Experience.astro
 │   ├── Skills.astro
 │   ├── Projects.astro
+│   ├── Tutorials.astro
 │   ├── Publications.astro
 │   ├── Contact.astro
 │   └── Footer.astro
@@ -35,6 +36,7 @@ src/
 │   ├── experience.json     # Work experience
 │   ├── skills.json         # Skill categories
 │   ├── projects.json       # Project cards
+│   ├── tutorials.json      # Tutorial cards
 │   └── publications.json   # Academic publications
 ├── layouts/
 │   └── Base.astro

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,140 @@
+# Onboarding Guide
+
+Welcome to the braboj.github.io project. This guide walks you through
+everything you need to contribute — from understanding what the project is,
+to making your first change.
+
+---
+
+## 1. What is this project?
+
+This is a personal portfolio site for Branimir Georgiev, deployed at
+https://braboj.github.io. It showcases experience, skills, projects,
+tutorials, and academic publications.
+
+The site is **static** — it has no backend, no database, and no login.
+Every page is generated at build time and served as plain HTML, CSS, and
+a small amount of JavaScript.
+
+---
+
+## 2. How does it work?
+
+The project uses [Astro](https://astro.build), a static site generator.
+
+The key idea is **separation of content and code**:
+
+- **Content** lives in `src/data/` as JSON files — no programming required
+  to update text, experience, or projects.
+- **Layout and structure** lives in `src/components/` as `.astro` files.
+- **Styles** live in `src/styles/global.css` — one file, no exceptions.
+
+At build time, Astro reads the JSON data, renders the components, and
+outputs a `dist/` folder of static HTML files. GitHub Actions then deploys
+that folder to GitHub Pages automatically on every push to `main`.
+
+```
+src/data/*.json   →   src/components/*.astro   →   dist/ (HTML)
+     ↑                                                    ↓
+  Edit here                                        Deployed here
+```
+
+---
+
+## 3. Project structure
+
+See `README.md` for the full project structure.
+
+---
+
+## 4. Setup
+
+**Prerequisites:** Node.js 18+ and npm.
+
+```bash
+git clone https://github.com/braboj/braboj.github.io.git
+cd braboj.github.io
+npm install
+npm run dev
+```
+
+The dev server starts at `http://localhost:4321` with hot reload.
+
+---
+
+## 5. Making changes
+
+### Content only (no code needed)
+
+Edit the relevant JSON file in `src/data/`. The dev server reloads
+automatically. See `docs/PLAYBOOK.md` for the full content editing
+reference.
+
+### Layout or style changes
+
+- **Component structure:** edit the relevant `.astro` file in
+  `src/components/`
+- **Styles:** edit `src/styles/global.css` only — no inline styles
+- **New section:** create a new `.astro` component, add a new JSON data
+  file, import and mount it in `src/pages/index.astro`, and add a nav
+  entry in `src/data/site.json`
+
+### Rule: default to `.astro`
+
+Only reach for React (`.tsx`) when the component needs client-side
+JavaScript state (e.g. a toggle, a form). Everything else is `.astro`.
+
+---
+
+## 6. Git workflow
+
+Always work on a branch — never commit directly to `main`.
+
+```bash
+git checkout -b feat/your-description   # or fix/, chore/, docs/
+# make changes
+npm run dev                             # verify locally first
+git add <files>
+git commit -m "feat: describe what changed"
+git push -u origin feat/your-description
+# open a PR on GitHub
+```
+
+### Commit prefixes
+
+See `docs/PLAYBOOK.md` for the full commit message conventions.
+
+### Before opening a PR
+
+- Run `npm run build` to catch any build errors
+- Check `git status` and `gh pr list` — make sure you are on the right
+  branch and there is no stale open PR
+
+---
+
+## 7. Deployment
+
+Merging to `main` triggers the GitHub Actions workflow in
+`.github/workflows/deploy.yml`. It builds the site and publishes the
+`dist/` folder to GitHub Pages. No manual steps needed.
+
+---
+
+## 8. Commands reference
+
+```bash
+npm run dev      # dev server with hot reload at localhost:4321
+npm run build    # production build to dist/
+npm run preview  # preview the production build locally
+```
+
+---
+
+## 9. Where to go from here
+
+- Read `CLAUDE.md` for the full set of design rules, quality standards,
+  and conventions used in this project.
+- Browse `src/data/` to understand the content structure before touching
+  any components.
+- Start with a small content change to get familiar with the workflow
+  before modifying components or CSS.

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -1,8 +1,7 @@
-# Imbra.Soft Website — Playbook
+# braboj.github.io — Playbook
 
-> **Windows note:** `gh` must be invoked via full path in bash:
-> `"/c/Program Files/GitHub CLI/gh.exe" <command>`
-> All examples below use `gh` for brevity — substitute the full path on Windows.
+Operational reference for common tasks. For project conventions and rules,
+see `CLAUDE.md`. For onboarding, see `docs/ONBOARDING.md`.
 
 ---
 
@@ -24,26 +23,27 @@ npm run preview   # preview the production build locally
 # Start a new feature or fix
 git checkout main
 git pull
-git checkout -b feature/description   # or fix/description
+git checkout -b feat/description   # or fix/, chore/, docs/
 
 # Stage and commit
 git add <file1> <file2>
 git commit -m "feat: short description"
 
 # Push and open PR
-git push -u origin feature/description
-gh pr create --repo Imbra-Ltd/imbra-ltd.github.io --title "feat: description" --body "..."
+git push -u origin feat/description
+gh pr create --title "feat: description" --body "..."
 ```
 
 ### Commit message conventions
 
 ```
-feat:     new feature
-fix:      bug fix
+feat:     new feature or content addition
+fix:      bug fix or correction
 chore:    maintenance, releases, tooling
 docs:     documentation only
 style:    CSS/formatting, no logic change
 refactor: code change that neither fixes a bug nor adds a feature
+test:     test additions or changes
 ```
 
 ### Release workflow
@@ -52,19 +52,28 @@ refactor: code change that neither fixes a bug nor adds a feature
 git checkout main
 git pull
 
-# 1. Empty release marker commit
-git commit --allow-empty -m "chore: release v0.0.1.0"
+# 1. Create release branch
+git checkout -b chore/release-vA.B.C.D
 
-# 2. Tag and push
-git tag v0.0.1.0
-git push
-git push origin v0.0.1.0
+# 2. Empty release marker commit
+git commit --allow-empty -m "chore: release vA.B.C.D"
 
-# 3. Create GitHub release
-gh release create v0.0.1.0 \
-  --repo Imbra-Ltd/imbra-ltd.github.io \
-  --title "v0.0.1.0" \
-  --notes "Release notes here"
+# 3. Push and open PR
+git push -u origin chore/release-vA.B.C.D
+gh pr create --title "chore: release vA.B.C.D" --body "Release vA.B.C.D"
+
+# 4. After PR is merged, tag main
+git checkout main && git pull
+git tag vA.B.C.D
+git push origin vA.B.C.D
+```
+
+### After a PR is merged
+
+```bash
+git checkout main && git pull
+git branch -d <branch>
+gh api -X DELETE repos/braboj/braboj.github.io/git/refs/heads/<branch>
 ```
 
 ### Useful git commands
@@ -77,7 +86,6 @@ git status                     # working tree status
 git stash                      # stash uncommitted changes
 git stash pop                  # restore stashed changes
 git tag                        # list all tags
-git checkout v0.0.1.0          # checkout a specific release
 ```
 
 ---
@@ -87,45 +95,25 @@ git checkout v0.0.1.0          # checkout a specific release
 ### Issues
 
 ```bash
-gh issue list --repo Imbra-Ltd/imbra-ltd.github.io --state open
-gh issue create --repo Imbra-Ltd/imbra-ltd.github.io --title "Title" --body "Body"
-gh issue edit 12 --repo Imbra-Ltd/imbra-ltd.github.io --title "New title"
-gh issue close 12 --repo Imbra-Ltd/imbra-ltd.github.io
-gh issue close 12 --repo Imbra-Ltd/imbra-ltd.github.io --comment "Reason"
-```
-
-### Milestones
-
-```bash
-# Create a milestone
-gh api repos/Imbra-Ltd/imbra-ltd.github.io/milestones \
-  --method POST --field title="v0.0.2.0"
-
-# Assign issue to milestone
-gh issue edit 8 --repo Imbra-Ltd/imbra-ltd.github.io --milestone "v0.0.2.0"
+gh issue list --state open
+gh issue create --title "Title" --body "Body"
+gh issue close 12 --comment "Reason"
 ```
 
 ### Pull requests
 
 ```bash
-gh pr create --repo Imbra-Ltd/imbra-ltd.github.io \
-  --title "feat: description" \
-  --body "## Summary\n..."
-
-gh pr list --repo Imbra-Ltd/imbra-ltd.github.io
-gh pr view 37 --repo Imbra-Ltd/imbra-ltd.github.io --json state,title
-gh pr merge 37 --repo Imbra-Ltd/imbra-ltd.github.io
+gh pr create --title "feat: description" --body "## Summary\n..."
+gh pr list
+gh pr status
+gh pr merge <number>
 ```
 
 ### Releases
 
 ```bash
-gh release create v0.0.1.0 \
-  --repo Imbra-Ltd/imbra-ltd.github.io \
-  --title "v0.0.1.0" \
-  --notes "Release notes here"
-
-gh release list --repo Imbra-Ltd/imbra-ltd.github.io
+gh release create vA.B.C.D --title "vA.B.C.D" --notes "Release notes"
+gh release list
 ```
 
 ---
@@ -134,34 +122,27 @@ gh release list --repo Imbra-Ltd/imbra-ltd.github.io
 
 All site content lives in `src/data/` as JSON. No component knowledge required.
 
-| File | Controls |
-|------|----------|
-| `src/data/site.json` | Nav links, hero stats, contact section (incl. Formspree endpoint), footer |
-| `src/data/products.json` | Portfolio cards and detail panels |
-| `src/data/services.json` | Services accordion items |
-| `src/data/expertise.json` | Domain expertise cards |
-| `src/data/publications.json` | Research publications with DOI links |
-| `src/data/process.json` | How We Work section steps |
-| `src/data/pricing.json` | Pricing page — all engagement models |
-
----
-
-## Third-party services
-
-| Service | Purpose | Config |
-|---------|---------|--------|
-| [Formspree](https://formspree.io) | Contact form → `contact@imbra.io` | `src/data/site.json` → `contact.formEndpoint` |
-| [Plausible](https://plausible.io) | Privacy-friendly analytics (no cookies, no consent banner) | Script tag in `src/layouts/Base.astro` |
+| File                         | Controls                                      |
+|------------------------------|-----------------------------------------------|
+| `src/data/site.json`         | Nav links, hero text, contact links, footer   |
+| `src/data/about.json`        | Biography story blocks                        |
+| `src/data/experience.json`   | Work experience entries                       |
+| `src/data/skills.json`       | Skill categories and items                    |
+| `src/data/projects.json`     | Project cards                                 |
+| `src/data/tutorials.json`    | Tutorial cards                                |
+| `src/data/publications.json` | Academic publications                         |
 
 ---
 
 ## Deployment
 
-Pushing to `main` triggers GitHub Actions which builds and deploys to GitHub Pages automatically.
+Pushing to `main` triggers GitHub Actions which builds and deploys to
+GitHub Pages automatically.
 
 ```bash
 git checkout main
+git pull
 git push   # triggers deploy
 ```
 
-Monitor: `https://github.com/Imbra-Ltd/imbra-ltd.github.io/actions`
+Monitor: `https://github.com/braboj/braboj.github.io/actions`


### PR DESCRIPTION
## Summary
- Add `docs/ONBOARDING.md` — top-down onboarding guide for junior developers
- Rewrite `docs/PLAYBOOK.md` — was pointing to wrong repo (Imbra-Ltd), now correct for braboj.github.io
- Update `README.md` — add missing Tutorials.astro and tutorials.json entries
- Update `CLAUDE.md` — simplify component architecture section, reference README as single source of truth for structure, add docs references

## Test plan
- [x] Review ONBOARDING.md reads logically top-down
- [x] Review PLAYBOOK.md commands are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)