### PR TITLE
docs: update CLAUDE.template.md with conventions from this project

### DIFF
--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -32,7 +32,8 @@
 - Use "[brand name]" in copy — not "[wrong variant]"
 
 ## Content
-All editable content lives in `[path]/` as [format]. Never hardcode content that a non-developer might want to change.
+All editable content lives in `[path]/` as [format]. Never hardcode content
+that a non-developer might want to change.
 
 | File           | Controls           |
 |----------------|--------------------|
@@ -41,15 +42,10 @@ All editable content lives in `[path]/` as [format]. Never hardcode content that
 
 ## Component architecture
 
-```
-src/components/
-├── interactive/      # [JS framework] islands — only components that need JS
-│   └── Component.tsx
-├── Component.astro
-└── ...
-```
+See `README.md` for the full project structure.
 
-**Rule:** [default component type]. Only reach for [heavier option] when [condition].
+**Rule:** [default component type]. Only reach for [heavier option] when
+[condition].
 
 ## Pages
 
@@ -59,12 +55,33 @@ src/components/
 | [Page]   | `/[path]/` |       |
 
 ## Git conventions
+- Commit messages must use conventional commit prefixes:
+  `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `style:`, `test:`
 - Always work on a branch — never commit directly to `main`
-- Exception: documentation-only changes may go directly to `main`
-- Branch naming: `feature/description` or `fix/description`
+- Exception: documentation-only changes (`docs/`, `README.md`, `CLAUDE.md`)
+  may go directly to `main`
+- Branch naming: `feat/description`, `fix/description`, `chore/description`,
+  `docs/description`
 - PRs should be small and focused — one concern per PR
 - Always test with `[dev command]` before committing
 - Do not commit `[build output]/` or `node_modules/`
+- **Before pushing or creating a PR**, always check the current branch and
+  open PR status with `git status` and `gh pr list`. If the previous PR is
+  closed or merged, create a new branch rather than pushing to a stale one.
+- **After a PR is merged**, delete both remote and local branch:
+  `git branch -d <branch>` and
+  `gh api -X DELETE repos/[owner]/[repo]/git/refs/heads/<branch>`.
+  Then pull main: `git checkout main && git pull`.
+
+## Versioning
+- Follows `vA.B.C.D` — A=major, B=minor, C=build, D=hotfix
+- No VERSION file — git tags only
+- Release process:
+  1. `git checkout -b chore/release-vA.B.C.D`
+  2. `git commit --allow-empty -m "chore: release vA.B.C.D"`
+  3. Push, open PR, merge
+  4. `git checkout main && git pull`
+  5. `git tag vA.B.C.D && git push origin vA.B.C.D`
 
 ## Commands
 ```
@@ -84,15 +101,20 @@ src/components/
 These are the non-negotiable standards for this project:
 
 **Content & architecture**
-- All editable content lives in `[data path]/` as [format] — never hardcoded in components
-- Default to [static component type]; only use [interactive framework] when client-side state is required
+- All editable content lives in `[data path]/` as [format] — never hardcoded
+  in components
+- Default to [static component type]; only use [interactive framework] when
+  client-side state is required
 - No dead code — remove unused components, CSS rules, and data files promptly
 
 **CSS**
-- All CSS in `[stylesheet path]` — no inline styles except dynamic/computed values
-- No hardcoded colour or spacing values — always use CSS custom properties from `:root`
+- All CSS in `[stylesheet path]` — no inline styles except dynamic/computed
+  values
+- No hardcoded colour or spacing values — always use CSS custom properties
+  from `:root`
 - Consistent naming convention: [e.g. BEM-like `.component-element`]
-- Maximum line length: 80 characters (exempt: JSON prose strings, third-party URLs)
+- Maximum line length: 80 characters (exempt: JSON prose strings, third-party
+  URLs)
 
 **Accessibility**
 - Semantic HTML: correct landmark elements and heading hierarchy
@@ -109,10 +131,18 @@ These are the non-negotiable standards for this project:
 
 **Documentation**
 - `CLAUDE.md` and `README.md` must always reflect the actual codebase
+- `docs/ONBOARDING.md` — onboarding guide for new contributors
+- `docs/PLAYBOOK.md` — operational reference for common tasks
+- `README.md` is the single source of truth for project structure — do not
+  duplicate it in other documents, reference it instead
 - No references to non-existent files, components, or services
 
 ## Documentation rule
 Before every commit, update all relevant documentation:
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
-- **`README.md`** — update if project structure, stack, or onboarding steps change
-- **`[PLAYBOOK or equivalent]`** — update if commands, workflow, or release process change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or
+  conventions change
+- **`README.md`** — update if project structure, stack, or onboarding steps
+  change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
+- **`docs/ONBOARDING.md`** — update if the contributor workflow changes


### PR DESCRIPTION
## Summary
- Add conventional commit prefixes section
- Add full branch naming conventions (feat/, fix/, chore/, docs/)
- Add PR safety checks and branch cleanup steps
- Add vA.B.C.D versioning with release process
- Add docs/ONBOARDING.md and docs/PLAYBOOK.md as standard project docs
- Establish README.md as single source of truth for project structure
- Update documentation rule to cover all four docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)