### PR TITLE
content: restore Heidelberg Materials bio section

### DIFF
--- a/src/data/about.json
+++ b/src/data/about.json
@@ -17,6 +17,14 @@
     ]
   },
   {
+    "heading": "The best documentation is a conversation",
+    "years": "2025 – Present",
+    "paragraphs": [
+      "At Heidelberg Materials, Branimir worked on PxTrend — an industrial historian built by Paranext. When the setup stalled, he drove to the nearest plant in Devnya, talked to the operators, learned from the clients, learned from the creator, and built understanding the only way that works — by experimenting, using it, and solving problems. The understanding of what a historian should do became the foundation for ImBrain.",
+      "A special thanks to Edgar Poth, founder of Paranext, for sharing his knowledge directly — shadowing him from 4am to 11pm through installations, upgrades, and live migrations of PxTrend was worth more than any technical book."
+    ]
+  },
+  {
     "heading": "When the Prophet goes to the mountain",
     "years": "2026 – Present",
     "paragraphs": [


### PR DESCRIPTION
## Summary
- Restores the "The best documentation is a conversation" bio block to `src/data/about.json`
- Was accidentally excluded from the previous merge (PR #44)

## Test plan
- [ ] Verify the About section shows the Heidelberg Materials block between Hilscher and Imbra