### PR TITLE
content: split projects into Showroom + Demos, add wuseria.com & restore imbra.io

### DIFF
--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -1,22 +1,39 @@
 ---
 import projects from '../data/projects.json';
+
+const groups = [
+  { id: 'showroom', title: 'Showroom', items: projects.showroom },
+  { id: 'demos', title: 'Demos', items: projects.demos },
+];
 ---
-<section id="projects" class="section">
+<section id="showroom" class="section">
   <div class="container">
-    <h2 class="section-title reveal">Projects</h2>
-    <div class="projects-grid">
-      {projects.map((project) => (
-        <div class="project-card reveal">
-          <div class="project-header">
-            <h3 class="project-name">{project.name}</h3>
-            <p class="project-tagline">{project.tagline}</p>
-          </div>
-          <p class="project-description">{project.description}</p>
-          {project.url && (
-            <a href={project.url} class="project-link" target="_blank" rel="noopener noreferrer">View →</a>
-          )}
+    <h2 class="section-title reveal">Showroom</h2>
+
+    {groups.map((group) => (
+      <div class="projects-group">
+        <h3 class="projects-group-title reveal">{group.title}</h3>
+        <div class="projects-grid">
+          {group.items.map((project) => (
+            <div class="project-card reveal">
+              <div class="project-header">
+                <h4 class="project-name">{project.name}</h4>
+                <p class="project-tagline">{project.tagline}</p>
+              </div>
+              <p class="project-description">{project.description}</p>
+              {project.url && (
+                <a
+                  href={project.url}
+                  class="project-link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Visit ${project.name}`}
+                >View →</a>
+              )}
+            </div>
+          ))}
         </div>
-      ))}
-    </div>
+      </div>
+    ))}
   </div>
 </section>

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,38 +1,54 @@
-[
-  {
-    "name": "braboj.github.io",
-    "tagline": "Personal portfolio and engineering profile",
-    "description": "This site — a minimal portfolio built with Astro, showcasing experience, skills, and projects. Open source and deployed via GitHub Pages.",
-    "url": "https://github.com/braboj/braboj.github.io"
-  },
-  {
-    "name": "demo-sensor-app",
-    "tagline": "Simulated sensor data sampling with REST and Angular",
-    "description": "A full-stack demo app simulating industrial sensor data — REST API built with Flask, visualised with Angular.",
-    "url": "https://github.com/braboj/demo-sensor-app"
-  },
-  {
-    "name": "demo-the-great-wall",
-    "tagline": "REST API with multiprocessing and Django",
-    "description": "A REST API demo using Django and multiprocessing — built to demonstrate parallel workload handling patterns.",
-    "url": "https://github.com/braboj/demo-the-great-wall"
-  },
-  {
-    "name": "demo-randomgen",
-    "tagline": "Random number generator REST API with Flask",
-    "description": "A minimal REST API demo built with Flask — clean starting point for API design patterns.",
-    "url": "https://github.com/braboj/demo-randomgen"
-  },
-  {
-    "name": "demo-hvlp",
-    "tagline": "Simplified MQTT protocol demo for training",
-    "description": "A simplified MQTT protocol implementation used for training engineers on industrial messaging patterns.",
-    "url": "https://github.com/braboj/demo-hvlp"
-  },
-  {
-    "name": "demo-state-machines",
-    "tagline": "State machine implementation in C",
-    "description": "A sample implementation of state machines in C — a fundamental pattern in embedded and industrial control systems.",
-    "url": "https://github.com/braboj/demo-state-machines"
-  }
-]
+{
+  "showroom": [
+    {
+      "name": "braboj.me",
+      "tagline": "Personal portfolio and engineering profile",
+      "description": "This site — a minimal portfolio built with Astro, showcasing experience, skills, and projects. Open source and deployed via GitHub Pages.",
+      "url": "https://braboj.me"
+    },
+    {
+      "name": "imbra.io",
+      "tagline": "Home of industrial software for the OT/IT boundary",
+      "description": "The company site for Imbra — home of Imbra Connect (industrial protocol SDKs for DeviceNet, Modbus, OPC-UA, and MQTT) and ImBrain (an industrial historian built for the plant floor).",
+      "url": "https://imbra.io"
+    },
+    {
+      "name": "wuseria.com",
+      "tagline": "Pick the right Fujifilm lens with lab data, not marketing",
+      "description": "A lightweight, offline-friendly web tool that ranks 243 Fujifilm lenses by optical quality across nine photography genres — landscape, portrait, wildlife, and more. Also covers camera comparisons, accessories, and a wiki.",
+      "url": "https://wuseria.com"
+    }
+  ],
+  "demos": [
+    {
+      "name": "demo-randomgen",
+      "tagline": "Random number generator REST API with Flask",
+      "description": "A minimal REST API demo built with Flask — clean starting point for API design patterns.",
+      "url": "https://github.com/braboj/demo-randomgen"
+    },
+    {
+      "name": "demo-sensor-app",
+      "tagline": "Simulated sensor data sampling with REST and Angular",
+      "description": "A full-stack demo app simulating industrial sensor data — REST API built with Flask, visualised with Angular.",
+      "url": "https://github.com/braboj/demo-sensor-app"
+    },
+    {
+      "name": "demo-the-great-wall",
+      "tagline": "REST API with multiprocessing and Django",
+      "description": "A REST API demo using Django and multiprocessing — built to demonstrate parallel workload handling patterns.",
+      "url": "https://github.com/braboj/demo-the-great-wall"
+    },
+    {
+      "name": "demo-hvlp",
+      "tagline": "Simplified MQTT protocol demo for training",
+      "description": "A simplified MQTT protocol implementation used for training engineers on industrial messaging patterns.",
+      "url": "https://github.com/braboj/demo-hvlp"
+    },
+    {
+      "name": "demo-state-machines",
+      "tagline": "State machine implementation in C",
+      "description": "A sample implementation of state machines in C — a fundamental pattern in embedded and industrial control systems.",
+      "url": "https://github.com/braboj/demo-state-machines"
+    }
+  ]
+}

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -6,7 +6,7 @@
     { "label": "About",        "href": "#about" },
     { "label": "Experience",   "href": "#experience" },
     { "label": "Skills",       "href": "#skills" },
-    { "label": "Projects",     "href": "#projects" },
+    { "label": "Showroom",     "href": "#showroom" },
     { "label": "Tutorials",    "href": "#tutorials" },
     { "label": "Publications", "href": "#publications" },
     { "label": "Get in Touch", "href": "#contact" }

--- a/src/data/tutorials.json
+++ b/src/data/tutorials.json
@@ -1,5 +1,17 @@
 [
   {
+    "name": "tutorial-git",
+    "tagline": "Let's learn git",
+    "description": "A beginner-friendly Git tutorial covering the core workflow — commits, branches, merges, and collaboration patterns.",
+    "url": "https://github.com/braboj/tutorial-git"
+  },
+  {
+    "name": "tutorial-python",
+    "tagline": "Source code for \"Learn Python by Example\"",
+    "description": "Companion repository for the Learn Python by Example course — practical examples for engineers picking up Python.",
+    "url": "https://github.com/braboj/tutorial-python"
+  },
+  {
     "name": "tutorial-azure",
     "tagline": "Azure cloud training",
     "description": "A hands-on Azure tutorial covering cloud fundamentals — compute, storage, and deployment for engineers new to the platform.",
@@ -10,12 +22,6 @@
     "tagline": "Docker training program",
     "description": "A structured Docker training program covering containers, images, volumes, and compose — built for engineers moving workloads to containers.",
     "url": "https://github.com/braboj/tutorial-docker"
-  },
-  {
-    "name": "tutorial-git",
-    "tagline": "Let's learn git",
-    "description": "A beginner-friendly Git tutorial covering the core workflow — commits, branches, merges, and collaboration patterns.",
-    "url": "https://github.com/braboj/tutorial-git"
   },
   {
     "name": "tutorial-microprocessor",
@@ -46,12 +52,6 @@
     "tagline": "Into the depths of parallel execution",
     "description": "A deep dive into operating system concepts with a focus on parallel execution — processes, threads, and synchronisation for systems engineers.",
     "url": "https://github.com/braboj/tutorial-os"
-  },
-  {
-    "name": "tutorial-python",
-    "tagline": "Source code for \"Learn Python by Example\"",
-    "description": "Companion repository for the Learn Python by Example course — practical examples for engineers picking up Python.",
-    "url": "https://github.com/braboj/tutorial-python"
   },
   {
     "name": "tutorial-testing",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -574,6 +574,24 @@ code {
 /* =========================================================
    Projects
    ========================================================= */
+.projects-group {
+  margin-top: 48px;
+}
+
+.projects-group:first-of-type {
+  margin-top: 0;
+}
+
+.projects-group-title {
+  font-size: 0.8125rem;
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin-bottom: 20px;
+}
+
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));


### PR DESCRIPTION
Closes #55

## Summary
- Renames `#projects` → `#showroom` and splits the section into two subgroups: **Showroom** (real, live sites) and **Demos** (GitHub demo repos)
- Adds **braboj.me** (replacing the duplicate braboj.github.io entry — same site), **imbra.io** (project card only), and **wuseria.com** to Showroom
- Reorders `tutorials.json` so `tutorial-git` and `tutorial-python` come first
- Adds `.projects-group` / `.projects-group-title` styles in `global.css` (matches existing `.skill-category` treatment)

## Out of scope
- imbra.io restoration is limited to the project card — About story, Hero/Contact social links, and contact email intentionally remain as the owner left them
- No screenshots / live previews — card-link treatment only

## Test plan
- [x] `npm run build` passes cleanly
- [ ] Visit `/` and confirm Showroom section shows two subgroups with correct cards
- [ ] Confirm nav "Showroom" link scrolls to the section
- [ ] Confirm Tutorials section now leads with git + python

🤖 Generated with [Claude Code](https://claude.com/claude-code)