### PR TITLE
content: add Imbra.io link to hero social row

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -19,6 +19,12 @@ import site from '../data/site.json';
             target="_blank"
             rel="noopener noreferrer"
           >GitHub</a>
+          <a
+            href={site.contact.imbra}
+            class="hero-social-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >Imbra.io</a>
         </div>
       </div>
 

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -15,7 +15,8 @@
   "contact": {
     "email": "braboj@abv.bg",
     "linkedin": "https://linkedin.com/in/branimir-georgiev",
-    "github": "https://github.com/braboj"
+    "github": "https://github.com/braboj",
+    "imbra": "https://imbra.io"
   },
   "footer": {
     "copyright": "Branimir Georgiev",


### PR DESCRIPTION
## Summary
- Adds an Imbra.io link to the hero social row, next to LinkedIn and GitHub
- Stores the URL under `contact.imbra` in `site.json` for consistency with the other socials
- Contact section is intentionally unchanged

## Test plan
- [x] `npm run build` passes
- [ ] Visit `/` after deploy and confirm the hero shows LinkedIn / GitHub / Imbra.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)