### PR TITLE
content: rename about heading; point hero CTA to Showroom

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -51,7 +51,7 @@ import site from '../data/site.json';
       <div class="hero-grid-actions">
         <div class="hero-actions">
           <a href="#contact" class="btn btn-primary">Get in touch</a>
-          <a href="#experience" class="btn btn-secondary">See experience</a>
+          <a href="#showroom" class="btn btn-secondary">See showroom</a>
           <a
             href="/cv/CV_Branimir_Georgiev.pdf"
             class="btn btn-secondary"

--- a/src/data/about.json
+++ b/src/data/about.json
@@ -17,7 +17,7 @@
     ]
   },
   {
-    "heading": "The best documentation is through a conversation",
+    "heading": "The best collaboration is through conversation",
     "years": "2025 – Present",
     "paragraphs": [
       "At Heidelberg Materials, Branimir worked on PxTrend — an industrial historian built by Paranext. When the setup stalled, he drove to the nearest plant in Devnya, talked to the operators, learned from the clients, learned from the creator, and built understanding the only way that works — by experimenting, using it, and solving problems. The understanding of what a historian should do became the foundation for what came next.",


### PR DESCRIPTION
## Summary
- Renames the third About section heading to "The best collaboration is through conversation" (was "...documentation is through a conversation")
- Changes the hero's middle secondary button from "See experience" → "See showroom" (target `#showroom`)

## Test plan
- [x] `npm run build` passes
- [ ] After deploy, confirm the About heading reads "The best collaboration is through conversation"
- [ ] Confirm hero shows: Get in touch · See showroom · Download CV — and that "See showroom" scrolls to the Showroom section

🤖 Generated with [Claude Code](https://claude.com/claude-code)