### PR TITLE
chore: move REST and gRPC to Industrial Protocols

### DIFF
--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -9,11 +9,11 @@
   },
   {
     "category": "Industrial Protocols",
-    "items": ["CAN", "CANopen", "CIP", "DeviceNet", "EtherNet/IP", "HART", "IO-Link", "Profibus", "Profinet", "Modbus", "MQTT", "Sparkplug", "OPC-DA", "OPC-UA", "MOST", "FlexRay", "LoRaWAN", "Zigbee"]
+    "items": ["CAN", "CANopen", "CIP", "DeviceNet", "EtherNet/IP", "HART", "IO-Link", "Profibus", "Profinet", "Modbus", "MQTT", "Sparkplug", "OPC-DA", "OPC-UA", "MOST", "FlexRay", "LoRaWAN", "Zigbee", "REST", "gRPC"]
   },
   {
     "category": "Software & Tools",
-    "items": ["PostgreSQL", "TimescaleDB", "ElasticSearch", "Docker", "Podman", "Azure", "Grafana", "GitLab", "GitHub", "REST", "gRPC", "arc42", "Mermaid", "JIRA"]
+    "items": ["PostgreSQL", "TimescaleDB", "ElasticSearch", "Docker", "Podman", "Azure", "Grafana", "GitLab", "GitHub", "arc42", "Mermaid", "JIRA"]
   },
   {
     "category": "Professional",


### PR DESCRIPTION
## Summary
- Moves `REST` and `gRPC` out of "Software & Tools" into "Industrial Protocols". They're protocols, not tools.

## Test plan
- [x] `npm run build` passes
- [ ] After deploy, confirm REST and gRPC appear under Industrial Protocols, not Software & Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)