### PR TITLE
chore: rename Industrial Protocols → Protocols & Interfaces

### DIFF
--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -8,7 +8,7 @@
     "items": ["Siemens PLCs", "TIA Portal", "Honeywell", "SCL", "HMI", "PID Tuning", "Advanced Process Control", "ATEX/IECEx"]
   },
   {
-    "category": "Industrial Protocols",
+    "category": "Protocols & Interfaces",
     "items": ["CAN", "CANopen", "CIP", "DeviceNet", "EtherNet/IP", "HART", "IO-Link", "Profibus", "Profinet", "Modbus", "MQTT", "Sparkplug", "OPC-DA", "OPC-UA", "MOST", "FlexRay", "LoRaWAN", "Zigbee", "REST", "gRPC"]
   },
   {


### PR DESCRIPTION
## Summary
- Renames the "Industrial Protocols" skills category to "Protocols & Interfaces" so it honestly covers REST and gRPC alongside MQTT, OPC-UA, Modbus, etc.
- No items added or removed.

## Test plan
- [x] `npm run build` passes
- [ ] After deploy, confirm the Skills section shows "Protocols & Interfaces" (not "Industrial Protocols") with the same item list

🤖 Generated with [Claude Code](https://claude.com/claude-code)